### PR TITLE
Updated Web Auth PR with Tests and Fixes

### DIFF
--- a/scripts/rabbit_dependencies.sh
+++ b/scripts/rabbit_dependencies.sh
@@ -28,24 +28,31 @@ Valid centos versions: 6, 7, 8
 function install_on_centos {
 
    if [[ "$DIST" == "6" ]]; then
-       erlang_url='https://dl.bintray.com/rabbitmq-erlang/rpm/erlang/21/el/6'
+       erlang_url='https://packagecloud.io/rabbitmq/erlang/el/6/$basearch'
+       erlang_package_name='erlang-21.3.8.21-1.el6.x86_64'
    elif [[ "$DIST" == "7" ]]; then
-       erlang_url='https://dl.bintray.com/rabbitmq-erlang/rpm/erlang/21/el/7'
+       erlang_url='https://packagecloud.io/rabbitmq/erlang/el/7/$basearch'
+       erlang_package_name='erlang-21.3.8.21-1.el7.x86_64'
    elif [[ "$DIST" == "8" ]]; then
-       erlang_url='https://dl.bintray.com/rabbitmq-erlang/rpm/erlang/21/el/8'
+       erlang_url='https://packagecloud.io/rabbitmq/erlang/el/8/$basearch'
+       erlang_package_name='erlang-21.3.8.21-1.el8.x86_64'
    else
        printf "Invalid centos version. 6, 7, and 8 are the only compatible versions\n"
        print_usage
    fi
 
    repo="## In /etc/yum.repos.d/rabbitmq-erlang.repo
-[rabbitmq-erlang]
-name=rabbitmq-erlang
+[rabbitmq_erlang]
+name=rabbitmq_erlang
 baseurl=$erlang_url
-gpgcheck=1
-gpgkey=https://dl.bintray.com/rabbitmq/Keys/rabbitmq-release-signing-key.asc
-repo_gpgcheck=0
-enabled=1"
+repo_gpgcheck=1
+gpgcheck=0
+enabled=1
+gpgkey=https://packagecloud.io/rabbitmq/erlang/gpgkey
+sslverify=1
+sslcacert=/etc/pki/tls/certs/ca-bundle.crt
+metadata_expire=300
+"
 
     if [[ ! -f "/etc/yum.repos.d/rabbitmq-erlang.repo" ]]; then
       echo "$repo" | ${prefix} tee -a /etc/yum.repos.d/rabbitmq-erlang.repo
@@ -53,7 +60,7 @@ enabled=1"
     else
       echo "\nrepo file /etc/yum.repos.d/rabbitmq-erlang.repo already exists\n"
     fi
-    ${prefix} yum install erlang
+    ${prefix} yum install $erlang_package_name
     exit_on_error
 }
 

--- a/scripts/rabbit_dependencies.sh
+++ b/scripts/rabbit_dependencies.sh
@@ -53,15 +53,14 @@ sslverify=1
 sslcacert=/etc/pki/tls/certs/ca-bundle.crt
 metadata_expire=300
 "
-
-    if [[ ! -f "/etc/yum.repos.d/rabbitmq-erlang.repo" ]]; then
-      echo "$repo" | ${prefix} tee -a /etc/yum.repos.d/rabbitmq-erlang.repo
+   if [[ -f "/etc/yum.repos.d/rabbitmq-erlang.repo" ]]; then
+      echo "\n/etc/yum.repos.d/rabbitmq-erlang.repo exists. renaming current file to rabbitmq-erlang.repo.old\n"
+      mv /etc/yum.repos.d/rabbitmq-erlang.repo /etc/yum.repos.d/rabbitmq-erlang.repo.old
       exit_on_error
-    else
-      echo "\nrepo file /etc/yum.repos.d/rabbitmq-erlang.repo already exists\n"
-    fi
-    ${prefix} yum install $erlang_package_name
-    exit_on_error
+   fi
+   echo "$repo" | ${prefix} tee -a /etc/yum.repos.d/rabbitmq-erlang.repo
+   ${prefix} yum install $erlang_package_name
+   exit_on_error
 }
 
 function install_on_debian {

--- a/services/core/PlatformDriverAgent/platform_driver/interfaces/modbus_tk/server.py
+++ b/services/core/PlatformDriverAgent/platform_driver/interfaces/modbus_tk/server.py
@@ -192,7 +192,7 @@ class Server (object):
         self._server.stop()
 
     def is_alive(self):
-        return self._server._thread.isAlive()
+        return self._server._thread.is_alive()
 
     def set_verbose(self, on=True):
         self._server.set_verbose(on)

--- a/volttron/platform/main.py
+++ b/volttron/platform/main.py
@@ -910,7 +910,7 @@ def start_volttron_process(opts):
             thread.start()
 
             gevent.sleep(0.1)
-            if not thread.isAlive():
+            if not thread.is_alive():
                 sys.exit()
         else:
             # Start RabbitMQ server if not running
@@ -941,7 +941,7 @@ def start_volttron_process(opts):
             thread.start()
 
             gevent.sleep(0.1)
-            if not thread.isAlive():
+            if not thread.is_alive():
                 sys.exit()
 
             gevent.sleep(1)

--- a/volttron/platform/web/__init__.py
+++ b/volttron/platform/web/__init__.py
@@ -125,14 +125,5 @@ def get_user_claim_from_bearer(bearer, web_secret_key=None, tls_public_key=None)
         # if isinstance(tls_public_key, str):
         #     pubkey = CertWrapper.load_cert(tls_public_key)
 
-    claims = jwt.decode(bearer, pubkey, algorithms=algorithm, options={"verify_exp": False})
-
-    exp = datetime.utcfromtimestamp(claims['exp'])
-    nbf = datetime.utcfromtimestamp(claims['nbf'])
-    now = datetime.utcnow()
-    # Now must be before expiration time and after Not Before time
-
-    if nbf <= now < exp:
-        return claims
-    else:
-        raise NotAuthorized
+    claims = jwt.decode(bearer, pubkey, algorithms=algorithm)
+    return claims

--- a/volttron/platform/web/__init__.py
+++ b/volttron/platform/web/__init__.py
@@ -124,7 +124,15 @@ def get_user_claim_from_bearer(bearer, web_secret_key=None, tls_public_key=None)
         pubkey = tls_public_key
         # if isinstance(tls_public_key, str):
         #     pubkey = CertWrapper.load_cert(tls_public_key)
-    claims = jwt.decode(bearer, pubkey, algorithms=algorithm)
+
+    claims = jwt.decode(bearer, pubkey, algorithms=algorithm, options={"verify_exp": False})
+
     exp = datetime.utcfromtimestamp(claims['exp'])
     nbf = datetime.utcfromtimestamp(claims['nbf'])
-    return claims if not (exp < datetime.utcnow() <= nbf) else {}
+    now = datetime.utcnow()
+    # Now must be before expiration time and after Not Before time
+
+    if nbf <= now < exp:
+        return claims
+    else:
+        raise NotAuthorized

--- a/volttron/platform/web/authenticate_endpoint.py
+++ b/volttron/platform/web/authenticate_endpoint.py
@@ -190,6 +190,10 @@ class AuthenticateEndpoints(object):
             _log.error("Unauthorized user attempted to connect to {}".format(env.get('PATH_INFO')))
             return Response('Unauthorized User', status="401 Unauthorized")
 
+        except jwt.ExpiredSignatureError:
+            _log.error("User attempted to connect to {} with an expired signature".format(env.get('PATH_INFO')))
+            return Response('Unauthorized User', status="401 Unauthorized")
+
         if claims.get('grant_type') != 'refresh_token' or not claims.get('groups'):
             return Response('Invalid refresh token.', status="401 Unauthorized")
         else:


### PR DESCRIPTION
# Description

- Added tests to verify functionality of POST, PUT, and DELETE requests.
- Modified get_user_claim_from_bearer to raise NotAuthorized if token expires.

Tests were failing due to an unexpected exception being raised in get_user_claim_from_bearer.
jwt.decode has a built-in check if the bearer has the exp claim, and if it has expired. 

From pyjwt documentation: "Expiration time is automatically verified in jwt.decode() and raises jwt.ExpiredSignatureError if the expiration time is in the past"
This can be ignored using the "verify_exp": False option, allowing us to handle the expiration as we see fit. This is the implementation included in this PR. 

The logic to properly handle the exp needed to be modified slightly as well to handle the true/false cases correctly, line 135 of web/__init__.py.

The current implementation will work, but using the built-in jwt.decode() handling of the expired signature may be cleaner. In that case, renew_auth_token() in authenticate_endpoint.py would need to be modified to catch jwt.ExpiredSignatureError instead of NotAuthorized.


## Type of change

- [X ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

Unit tests have been re-written to verify the new use cases.